### PR TITLE
Feature/shelter details rendering

### DIFF
--- a/cypress/e2e/shelter-ratings-form.cy.js
+++ b/cypress/e2e/shelter-ratings-form.cy.js
@@ -15,7 +15,7 @@ describe("User Flow: As a user, I should be able to submit a form on the shelter
     cy.get("section#communityReviews > h2").contains("Community Reviews")
     cy.get("section#communityReviews > h2").should("be.visible")
     cy.get("section#communityReviews > article > div > p").should("be.visible")
-    cy.get("section#communityReviews > p").contains("these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
+    cy.get("section#communityReviews > p").contains("These ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
 
     cy.get("img#flag").should("be.visible")
     .should("have.attr", "src")

--- a/cypress/e2e/shelter-ratings-form.cy.js
+++ b/cypress/e2e/shelter-ratings-form.cy.js
@@ -15,7 +15,7 @@ describe("User Flow: As a user, I should be able to submit a form on the shelter
     cy.get("section#communityReviews > h2").contains("Community Reviews")
     cy.get("section#communityReviews > h2").should("be.visible")
     cy.get("section#communityReviews > article > div > p").should("be.visible")
-    cy.get("section#communityReviews > p").contains("these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
+    cy.get("#communityReviews > :nth-child(3)").contains("these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
 
     cy.get("img#flag").should("be.visible")
     .should("have.attr", "src")

--- a/cypress/e2e/shelter-ratings-form.cy.js
+++ b/cypress/e2e/shelter-ratings-form.cy.js
@@ -15,7 +15,7 @@ describe("User Flow: As a user, I should be able to submit a form on the shelter
     cy.get("section#communityReviews > h2").contains("Community Reviews")
     cy.get("section#communityReviews > h2").should("be.visible")
     cy.get("section#communityReviews > article > div > p").should("be.visible")
-    cy.get("section#communityReviews > p").contains("These ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
+    cy.get("section#communityReviews > p").contains("these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them")
 
     cy.get("img#flag").should("be.visible")
     .should("have.attr", "src")

--- a/src/app/list/[id]/page.jsx
+++ b/src/app/list/[id]/page.jsx
@@ -122,7 +122,7 @@ export default function ShelterPage({ params }) {
               </div>
             </article>
           }
-          <p>These ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them</p>
+          <p>these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them</p>
         </section>
 
         <RateForm id={params.id} error={revError} reviewed={reviewed} submitReview={submitReview} />

--- a/src/app/list/[id]/page.jsx
+++ b/src/app/list/[id]/page.jsx
@@ -105,21 +105,24 @@ export default function ShelterPage({ params }) {
 
         <section id="communityReviews" className={shelterPage.reviews}>
           <h2>Community Reviews</h2>
-          <article className={shelterPage.scores}>
-            <div>
-              <p>{shelter.avgStaff}</p>
-              <img id="flag" className={shelterPage.icons} src={'/flag.png'} />
-            </div>
-            <div>
-              <p>{shelter.avgSafety}</p>
-              <img id="home" className={shelterPage.icons} src={'/home.png'} />
-            </div>
-            <div>
-              <p>{shelter.avgClean}</p>
-              <img id="mop" className={shelterPage.icons} src={'/mop.png'} />
-            </div>
-          </article>
-          <p>these ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them</p>
+          {!shelterPage.reviews 
+            ? <p>There are no reviews of this shelter</p>  
+            :<article className={shelterPage.scores}>
+              <div>
+                <p>{shelter.avgStaff}</p>
+                <img id="flag" className={shelterPage.icons} src={'/flag.png'} />
+              </div>
+              <div>
+                <p>{shelter.avgSafety}</p>
+                <img id="home" className={shelterPage.icons} src={'/home.png'} />
+              </div>
+              <div>
+                <p>{shelter.avgClean}</p>
+                <img id="mop" className={shelterPage.icons} src={'/mop.png'} />
+              </div>
+            </article>
+          }
+          <p>These ratings are averaged from community reviews and are intended to reflect the experience of those who have received services here, not those who provide them</p>
         </section>
 
         <RateForm id={params.id} error={revError} reviewed={reviewed} submitReview={submitReview} />

--- a/src/app/list/[id]/page.jsx
+++ b/src/app/list/[id]/page.jsx
@@ -92,7 +92,7 @@ export default function ShelterPage({ params }) {
             <p>{`${shelter.city}, ${shelter.state} ${shelter.zip}`}</p>
           </div>
           <div className={shelterPage.clientServices}>
-            {shelter.websiteUrl && <a href={`${shelter.websiteUrl}`}>website</a>}
+            {shelter.websiteUrl && <a href={`http://${shelter.websiteUrl}`}>website</a>}
             <p>{shelter.phoneNumber}</p>
           </div>
           <div id="verified" className={shelterPage.verify} >


### PR DESCRIPTION
# Description
I fixed the bug. I had to add `http://` to the beginning of the interpolated website. It now takes the user out of our site and navigates to the new site.
I also added conditional rendering to the reviews section so that if there are no reviews yet, a message will load in place of where the reviews would be. 

## Questions for Reviewers
I'm not sure how to test the conditional rendering on the shelter details page, since all of the shelters I can see on the site have reviews. Please advise.

## Checks
[x] Any breaking tests have been addressed/fixed

This PR closes #48
